### PR TITLE
Improve preview page metrics and stats

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -461,8 +461,25 @@ button.primary {
   position: relative;
 }
 
+.script-page::after {
+  content: 'Page ' attr(data-page-number);
+  position: absolute;
+  bottom: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.4);
+  pointer-events: none;
+}
+
 [data-theme='dark'] .script-page {
   background: #e9edf5;
+}
+
+[data-theme='dark'] .script-page::after {
+  color: rgba(15, 23, 42, 0.5);
 }
 
 .script-line {


### PR DESCRIPTION
## Summary
- track preview pagination so the caret-aware indicator and runtime use actual page counts
- format outline labels and insights with locale-aware counts for easier reading
- render page numbers on each preview page and synchronise the indicator when the caret moves

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2378a10a0832b848836f7e4f9133f