### PR TITLE
Adjust right rail layout for mid-size viewports

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1612,9 +1612,7 @@ body.drawer-open {
   .header-metrics {
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   }
-}
 
-@media (max-width: 960px) {
   .workspace {
     grid-template-columns: minmax(0, 1fr);
   }


### PR DESCRIPTION
## Summary
- raise the responsive breakpoint that collapses the workspace to a single column to 1100px
- allow the outline/insights column to stack beneath the editor instead of overlapping the formatted preview on mid-size screens

## Testing
- Manual visual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d26c24da44832b8996a00a6a366090