### PR TITLE
Add contextual typing suggestions for script editor

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1087,6 +1087,78 @@ kbd {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
+.suggestion-panel {
+  margin-top: 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--panel-border);
+  background: var(--panel-solid);
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
+.suggestion-panel[hidden] {
+  display: none;
+}
+
+.suggestion-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.suggestion-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.suggestion-option {
+  background: rgba(79, 70, 229, 0.12);
+  color: var(--accent-strong);
+  border-radius: 999px;
+  border: 1px solid rgba(79, 70, 229, 0.25);
+  padding: 0.35rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1;
+  box-shadow: none;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), box-shadow var(--transition), border-color var(--transition);
+}
+
+.suggestion-option:hover,
+.suggestion-option.is-active,
+.suggestion-option:focus-visible {
+  background: var(--accent);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 12px 28px rgba(79, 70, 229, 0.28);
+}
+
+[data-theme='dark'] .suggestion-option {
+  background: rgba(129, 140, 248, 0.16);
+  border-color: rgba(129, 140, 248, 0.35);
+  color: var(--accent);
+}
+
+[data-theme='dark'] .suggestion-option.is-active,
+[data-theme='dark'] .suggestion-option:hover,
+[data-theme='dark'] .suggestion-option:focus-visible {
+  background: var(--accent-strong);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 14px 32px rgba(129, 140, 248, 0.35);
+}
+
+.writing-panel[data-view-mode='formatted'] .suggestion-panel {
+  display: none !important;
+}
+
 .status-tip-label {
   font-size: 0.8rem;
   text-transform: uppercase;

--- a/index.html
+++ b/index.html
@@ -204,6 +204,11 @@
               </div>
             </div>
 
+            <div class="suggestion-panel" id="suggestionPanel" hidden>
+              <span class="suggestion-label" id="suggestionLabel"></span>
+              <div class="suggestion-options" id="suggestionList" role="listbox"></div>
+            </div>
+
             <div class="status-bar">
               <div class="status-left">
                 <span class="status-tip-label">Flow tip</span>


### PR DESCRIPTION
## Summary
- add a suggestion panel below the editor to surface predictive completions
- track script content to offer contextual suggestions for scenes, characters, and parentheticals with keyboard navigation
- refresh suggestion data during formatting and hide suggestions when switching views

## Testing
- node --check js/app.js

------
https://chatgpt.com/codex/tasks/task_e_68d362f432f8832b87573ab7bc2c4661