### PR TITLE
Add floating predictive text chooser

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -760,6 +760,7 @@ kbd {
   gap: 1.5rem;
   flex: 1;
   min-height: 0;
+  position: relative;
 }
 
 .writing-stage {
@@ -1088,15 +1089,21 @@ kbd {
 }
 
 .suggestion-panel {
-  margin-top: 1.25rem;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 20;
   border-radius: var(--radius-md);
   border: 1px solid var(--panel-border);
   background: var(--panel-solid);
-  padding: 0.75rem 1rem;
+  padding: 0.75rem 0.85rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.2);
+  width: max-content;
+  max-width: min(22rem, calc(100% - 2.5rem));
+  pointer-events: auto;
 }
 
 .suggestion-panel[hidden] {
@@ -1113,22 +1120,29 @@ kbd {
 
 .suggestion-options {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 14rem;
+  overflow-y: auto;
+  padding-right: 0.2rem;
 }
 
 .suggestion-option {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
   background: rgba(79, 70, 229, 0.12);
   color: var(--accent-strong);
-  border-radius: 999px;
+  border-radius: var(--radius-sm);
   border: 1px solid rgba(79, 70, 229, 0.25);
-  padding: 0.35rem 0.85rem;
-  font-size: 0.85rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
   font-weight: 600;
-  line-height: 1;
+  line-height: 1.3;
   box-shadow: none;
   cursor: pointer;
   transition: background var(--transition), color var(--transition), box-shadow var(--transition), border-color var(--transition);
+  text-align: left;
 }
 
 .suggestion-option:hover,


### PR DESCRIPTION
## Summary
- anchor the predictive text panel to the caret and keep it positioned as the editor scrolls
- add keyboard support for Enter selection and ensure active options stay in view
- refresh the suggestion panel styling into a columnar popup that supports pointer interaction

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d36dc40e90832b97358b50385c3a98