### PR TITLE
Limit predictive character suggestions to uppercase input

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -863,6 +863,9 @@ function handleSuggestionKeydown(event) {
     return true;
   }
   if (event.key === 'Enter') {
+    if (event.shiftKey) {
+      return false;
+    }
     event.preventDefault();
     applyActiveSuggestion();
     return true;
@@ -945,7 +948,7 @@ function determineSuggestionContext(lineInfo, caret) {
   const uppercaseBeforeCaret = beforeCaret.toUpperCase();
   const trimmedBeforeCaret = uppercaseBeforeCaret.trim();
 
-  const isCharacterLine = lineInfo.type === 'character' || isCharacter(uppercaseContent);
+  const isCharacterLine = lineInfo.type === 'character' || isCharacter(content);
   if (isCharacterLine && (trimmedBeforeCaret.length > 0 || uppercaseContent.includes('('))) {
     const lastOpenParen = uppercaseBeforeCaret.lastIndexOf('(');
     const lastCloseParen = uppercaseBeforeCaret.lastIndexOf(')');


### PR DESCRIPTION
## Summary
- stop character suggestions from appearing when the current line contains lowercase dialogue text
- allow Shift+Enter to insert a plain newline without accepting an active suggestion

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d371b9b1b8832b94f5550c37fac072