### PR TITLE
Declutter the Scriptius workspace UI

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,32 +1,32 @@
 :root {
   color-scheme: light;
-  --bg: #eef2ff;
-  --bg-alt: #e0e7ff;
-  --panel: rgba(255, 255, 255, 0.78);
-  --panel-solid: rgba(255, 255, 255, 0.95);
-  --panel-border: rgba(99, 102, 241, 0.18);
-  --panel-border-strong: rgba(99, 102, 241, 0.3);
-  --text: #0f172a;
-  --text-muted: #475569;
-  --text-soft: #64748b;
-  --accent: #4f46e5;
-  --accent-strong: #4338ca;
-  --accent-soft: rgba(79, 70, 229, 0.16);
-  --accent-glow: rgba(99, 102, 241, 0.2);
-  --focus-ring: 0 0 0 3px rgba(99, 102, 241, 0.45);
-  --shadow-sm: 0 18px 30px rgba(15, 23, 42, 0.08);
-  --shadow-lg: 0 48px 140px rgba(99, 102, 241, 0.18);
-  --blur: saturate(160%) blur(22px);
-  --radius-lg: 28px;
-  --radius-md: 18px;
+  --bg: #f6f7ff;
+  --bg-alt: #eef1ff;
+  --panel: rgba(255, 255, 255, 0.82);
+  --panel-solid: rgba(255, 255, 255, 0.94);
+  --panel-border: rgba(99, 102, 241, 0.12);
+  --panel-border-strong: rgba(99, 102, 241, 0.2);
+  --text: #111827;
+  --text-muted: #4b5563;
+  --text-soft: #6b7280;
+  --accent: #6366f1;
+  --accent-strong: #4f46e5;
+  --accent-soft: rgba(99, 102, 241, 0.12);
+  --accent-glow: rgba(99, 102, 241, 0.22);
+  --focus-ring: 0 0 0 3px rgba(99, 102, 241, 0.35);
+  --shadow-sm: 0 18px 46px rgba(15, 23, 42, 0.08);
+  --shadow-lg: 0 52px 140px rgba(99, 102, 241, 0.16);
+  --blur: saturate(160%) blur(18px);
+  --radius-lg: 24px;
+  --radius-md: 16px;
   --radius-sm: 12px;
   --positive: #16a34a;
-  --positive-soft: rgba(34, 197, 94, 0.18);
+  --positive-soft: rgba(22, 163, 74, 0.16);
   --warning: #f59e0b;
-  --warning-soft: rgba(250, 204, 21, 0.18);
+  --warning-soft: rgba(245, 158, 11, 0.18);
   --danger: #ef4444;
   --danger-soft: rgba(239, 68, 68, 0.18);
-  --grid-color: rgba(79, 70, 229, 0.08);
+  --grid-color: rgba(99, 102, 241, 0.08);
   --transition: 160ms ease;
 }
 
@@ -34,27 +34,27 @@
   color-scheme: dark;
   --bg: #020617;
   --bg-alt: #0b1224;
-  --panel: rgba(15, 23, 42, 0.72);
-  --panel-solid: rgba(15, 23, 42, 0.88);
-  --panel-border: rgba(129, 140, 248, 0.28);
-  --panel-border-strong: rgba(129, 140, 248, 0.45);
+  --panel: rgba(15, 23, 42, 0.78);
+  --panel-solid: rgba(15, 23, 42, 0.92);
+  --panel-border: rgba(129, 140, 248, 0.24);
+  --panel-border-strong: rgba(129, 140, 248, 0.38);
   --text: #f8fafc;
   --text-muted: #c7d2fe;
-  --text-soft: #94a3b8;
-  --accent: #818cf8;
-  --accent-strong: #6366f1;
+  --text-soft: #a5b4fc;
+  --accent: #a5b4fc;
+  --accent-strong: #818cf8;
   --accent-soft: rgba(129, 140, 248, 0.2);
   --accent-glow: rgba(129, 140, 248, 0.32);
-  --focus-ring: 0 0 0 3px rgba(129, 140, 248, 0.45);
-  --shadow-sm: 0 24px 32px rgba(2, 6, 23, 0.6);
-  --shadow-lg: 0 60px 160px rgba(2, 6, 23, 0.8);
+  --focus-ring: 0 0 0 3px rgba(129, 140, 248, 0.38);
+  --shadow-sm: 0 28px 40px rgba(2, 6, 23, 0.65);
+  --shadow-lg: 0 64px 170px rgba(2, 6, 23, 0.78);
   --positive: #4ade80;
   --positive-soft: rgba(74, 222, 128, 0.2);
   --warning: #fbbf24;
   --warning-soft: rgba(251, 191, 36, 0.22);
   --danger: #f87171;
-  --danger-soft: rgba(248, 113, 113, 0.22);
-  --grid-color: rgba(129, 140, 248, 0.08);
+  --danger-soft: rgba(248, 113, 113, 0.24);
+  --grid-color: rgba(129, 140, 248, 0.1);
 }
 
 * {
@@ -69,13 +69,13 @@ body {
 body {
   margin: 0;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: radial-gradient(circle at top right, var(--bg-alt) 0%, transparent 55%), var(--bg);
+  background: linear-gradient(160deg, var(--bg) 0%, #ffffff 45%, var(--bg-alt) 100%);
   color: var(--text);
   display: flex;
   flex-direction: column;
   min-height: 100vh;
   position: relative;
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
 a {
@@ -113,42 +113,42 @@ textarea {
 .background-orb {
   position: absolute;
   border-radius: 50%;
-  opacity: 0.65;
-  mix-blend-mode: screen;
+  opacity: 0.35;
+  filter: blur(28px);
 }
 
 .orb-one {
-  width: 520px;
-  height: 520px;
-  background: radial-gradient(circle at center, rgba(79, 70, 229, 0.35) 0%, transparent 65%);
-  top: -140px;
-  left: -160px;
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle at center, rgba(99, 102, 241, 0.28) 0%, transparent 70%);
+  top: -120px;
+  left: -140px;
 }
 
 .orb-two {
-  width: 640px;
-  height: 640px;
-  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.24) 0%, transparent 65%);
-  bottom: -220px;
-  right: -200px;
+  width: 520px;
+  height: 520px;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.22) 0%, transparent 70%);
+  bottom: -180px;
+  right: -160px;
 }
 
 .background-grid {
   position: absolute;
   inset: 0;
-  background-image: linear-gradient(transparent 27px, var(--grid-color) 28px),
-    linear-gradient(90deg, transparent 27px, var(--grid-color) 28px);
-  background-size: 28px 28px;
-  opacity: 0.35;
+  background-image: linear-gradient(transparent 35px, var(--grid-color) 36px),
+    linear-gradient(90deg, transparent 35px, var(--grid-color) 36px);
+  background-size: 48px 48px;
+  opacity: 0.18;
 }
 
 .app-shell {
-  width: min(1200px, calc(100% - 3rem));
+  width: min(1100px, calc(100% - 3rem));
   margin: 0 auto;
-  padding: 3rem 0 4rem;
+  padding: 2.75rem 0 3.5rem;
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 2rem;
   position: relative;
 }
 
@@ -167,7 +167,7 @@ button {
   border-radius: var(--radius-md);
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
   color: #fff;
-  padding: 0.6rem 1.4rem;
+  padding: 0.55rem 1.25rem;
   font-size: 0.95rem;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -176,12 +176,13 @@ button {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  box-shadow: 0 14px 30px rgba(99, 102, 241, 0.16);
   transition: transform var(--transition), box-shadow var(--transition), opacity var(--transition), background var(--transition);
 }
 
 button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 14px 32px rgba(79, 70, 229, 0.24);
+  box-shadow: 0 18px 40px rgba(99, 102, 241, 0.2);
 }
 
 button:active {
@@ -194,16 +195,27 @@ button:focus-visible {
 }
 
 button.ghost {
-  background: transparent;
+  background: rgba(99, 102, 241, 0.06);
   color: var(--text);
   border: 1px solid var(--panel-border);
   box-shadow: none;
 }
 
 button.ghost:hover {
-  background: var(--accent-soft);
+  background: rgba(99, 102, 241, 0.12);
   color: var(--accent);
   box-shadow: none;
+}
+
+[data-theme='dark'] button.ghost {
+  background: rgba(129, 140, 248, 0.18);
+  color: #f8fafc;
+  border-color: rgba(129, 140, 248, 0.35);
+}
+
+[data-theme='dark'] button.ghost:hover {
+  background: rgba(129, 140, 248, 0.26);
+  color: #fff;
 }
 
 button.primary {
@@ -282,10 +294,10 @@ kbd {
 }
 
 .app-header {
-  padding: 2.5rem 2.75rem 2.75rem;
+  padding: 2.25rem 2.5rem 2.5rem;
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 2rem;
   position: relative;
 }
 
@@ -293,8 +305,8 @@ kbd {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top left, rgba(79, 70, 229, 0.14), transparent 55%);
-  opacity: 0.75;
+  background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.12), transparent 60%);
+  opacity: 0.7;
   border-radius: inherit;
   pointer-events: none;
 }
@@ -319,16 +331,16 @@ kbd {
 }
 
 .logo {
-  width: 56px;
-  height: 56px;
-  border-radius: 20px;
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.22), rgba(56, 189, 248, 0.18));
+  width: 54px;
+  height: 54px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(56, 189, 248, 0.16));
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.6rem;
+  font-size: 1.5rem;
   color: var(--accent);
-  box-shadow: 0 12px 30px rgba(79, 70, 229, 0.22);
+  box-shadow: 0 12px 30px rgba(99, 102, 241, 0.18);
 }
 
 .title-group {
@@ -449,60 +461,73 @@ kbd {
 
 .header-secondary {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
-  gap: 2.2rem;
-  align-items: start;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 2rem;
+  align-items: stretch;
 }
 
-.hero-copy h1 {
-  font-size: clamp(1.8rem, 3vw, 2.4rem);
-  margin: 0 0 0.75rem;
+.header-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-.hero-copy p {
-  margin: 0 0 1.25rem;
+.header-intro h1 {
+  font-size: clamp(1.8rem, 3vw, 2.3rem);
+  margin: 0;
+}
+
+.header-intro p {
+  margin: 0;
   color: var(--text-soft);
-  max-width: 38ch;
+  max-width: 45ch;
   line-height: 1.6;
 }
 
-.hero-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.65rem;
-}
-
-.hero-list li {
+.header-highlights {
   display: flex;
-  align-items: flex-start;
-  gap: 0.45rem;
-  color: var(--text-muted);
-  font-size: 0.95rem;
+  flex-wrap: wrap;
+  gap: 0.6rem;
 }
 
-.hero-list li::before {
-  content: '▹';
-  color: var(--accent);
-  font-size: 0.85rem;
-  margin-top: 0.15rem;
+.highlight-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--accent-strong);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+[data-theme='dark'] .highlight-pill {
+  background: rgba(129, 140, 248, 0.2);
+  border-color: rgba(129, 140, 248, 0.38);
+  color: #fff;
 }
 
 .header-metrics {
   display: grid;
   gap: 1.25rem;
+  align-content: start;
+  min-width: 0;
 }
 
 .status-card,
 .progress-card {
-  padding: 1.5rem 1.75rem;
+  padding: 1.35rem 1.6rem;
   border-radius: var(--radius-lg);
   border: 1px solid var(--panel-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  background: var(--panel-solid);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), 0 18px 36px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.9rem;
 }
 
 .status-label {
@@ -702,7 +727,8 @@ kbd {
   padding: 0.3rem;
   border-radius: 999px;
   border: 1px solid var(--panel-border);
-  background: rgba(99, 102, 241, 0.08);
+  background: var(--panel-solid);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
 .view-switch__btn {
@@ -900,14 +926,14 @@ kbd {
 .panel textarea {
   min-height: 140px;
   border-radius: var(--radius-md);
-  background: rgba(99, 102, 241, 0.06);
+  background: var(--panel-solid);
   border: 1px solid var(--panel-border);
   color: var(--text);
   resize: vertical;
 }
 
 [data-theme='dark'] .panel textarea {
-  background: rgba(99, 102, 241, 0.1);
+  background: rgba(99, 102, 241, 0.16);
 }
 
 .scene-list {
@@ -939,7 +965,7 @@ kbd {
   color: var(--text);
   font-weight: 500;
   letter-spacing: 0;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
   transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
 }
 
@@ -985,8 +1011,9 @@ kbd {
   justify-content: space-between;
   border-radius: var(--radius-md);
   padding: 1rem 1.25rem;
-  background: rgba(99, 102, 241, 0.08);
+  background: var(--panel-solid);
   border: 1px solid var(--panel-border);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.06);
 }
 
 .toolbar-snippets {
@@ -1026,7 +1053,7 @@ kbd {
 }
 
 .toolbar-chip {
-  background: transparent;
+  background: rgba(99, 102, 241, 0.06);
   border: 1px solid var(--panel-border);
   border-radius: 999px;
   padding: 0.5rem 1.1rem;
@@ -1039,11 +1066,23 @@ kbd {
 
 .toolbar-chip:hover,
 .toolbar-chip:focus-visible {
-  background: var(--accent-soft);
+  background: rgba(99, 102, 241, 0.12);
   color: var(--accent);
   border-color: var(--accent);
   box-shadow: none;
   transform: translateY(-1px);
+}
+
+[data-theme='dark'] .toolbar-chip {
+  background: rgba(129, 140, 248, 0.18);
+  color: #f8fafc;
+  border-color: rgba(129, 140, 248, 0.35);
+}
+
+[data-theme='dark'] .toolbar-chip:hover,
+[data-theme='dark'] .toolbar-chip:focus-visible {
+  background: rgba(129, 140, 248, 0.26);
+  color: #fff;
 }
 
 #scriptEditor {
@@ -1056,9 +1095,9 @@ kbd {
   font-family: 'Courier Prime', 'Courier New', monospace;
   font-size: 1.02rem;
   line-height: 1.65;
-  background: rgba(15, 23, 42, 0.02);
+  background: var(--panel-solid);
   color: var(--text);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 24px 50px rgba(15, 23, 42, 0.08);
   transition: box-shadow var(--transition), border-color var(--transition), background var(--transition);
   white-space: pre;
 }
@@ -1066,13 +1105,17 @@ kbd {
 #scriptEditor:focus {
   outline: none;
   border-color: var(--accent);
-  background: var(--panel-solid);
+  background: #fff;
   box-shadow: var(--focus-ring);
 }
 
 [data-theme='dark'] #scriptEditor {
-  background: rgba(15, 23, 42, 0.45);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+[data-theme='dark'] #scriptEditor:focus {
+  background: rgba(15, 23, 42, 0.72);
 }
 
 .status-bar {
@@ -1085,7 +1128,7 @@ kbd {
   border: 1px solid var(--panel-border);
   background: var(--panel-solid);
   padding: 1rem 1.25rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 18px 32px rgba(15, 23, 42, 0.06);
 }
 
 .suggestion-panel {
@@ -1199,11 +1242,17 @@ kbd {
 .hint-chip {
   border-radius: 999px;
   border: 1px solid var(--panel-border);
-  background: rgba(99, 102, 241, 0.08);
-  color: var(--text-muted);
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--accent-strong);
   padding: 0.45rem 0.85rem;
   font-size: 0.85rem;
   font-weight: 500;
+}
+
+[data-theme='dark'] .hint-chip {
+  background: rgba(129, 140, 248, 0.26);
+  border-color: rgba(129, 140, 248, 0.38);
+  color: #f8fafc;
 }
 
 .hint-chip kbd {
@@ -1217,12 +1266,13 @@ kbd {
   overflow-y: auto;
   border-radius: var(--radius-lg);
   border: 1px solid var(--panel-border);
-  background: rgba(99, 102, 241, 0.06);
+  background: var(--panel-solid);
   padding: 1.75rem 1.25rem;
   display: flex;
   justify-content: center;
   align-items: flex-start;
   scrollbar-gutter: stable both-edges;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 22px 40px rgba(15, 23, 42, 0.08);
 }
 
 #scriptPreview {
@@ -1777,8 +1827,12 @@ body.drawer-open {
     align-items: flex-start;
   }
 
-  .hero-copy p {
+  .header-intro p {
     max-width: none;
+  }
+
+  .header-highlights {
+    gap: 0.5rem;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -102,16 +102,16 @@
         </div>
 
         <div class="header-secondary">
-          <div class="hero-copy">
-            <h1>Design your next script beat by beat</h1>
+          <div class="header-intro">
+            <h1>Quiet workspace for your screenplay</h1>
             <p>
-              Snap between outline, formatted pages and insights while autosave keeps every draft safe on this device.
+              Keep the outline, formatted pages and insights neatly arranged so the writing stays front and centre.
             </p>
-            <ul class="hero-list">
-              <li>Break scenes into beats straight from the outline panel.</li>
-              <li>Preview formatted pages instantly as you type.</li>
-              <li>Share secure, local links whenever you need feedback.</li>
-            </ul>
+            <div class="header-highlights" role="list">
+              <span class="highlight-pill" role="listitem">Outline &amp; draft side by side</span>
+              <span class="highlight-pill" role="listitem">Autosave with personal library</span>
+              <span class="highlight-pill" role="listitem">Export Fountain, text or PDF</span>
+            </div>
           </div>
           <div class="header-metrics">
             <article class="status-card glass-panel">
@@ -160,7 +160,7 @@
             <div class="panel-heading">
               <h2>Write &amp; preview</h2>
               <p class="panel-description writing-panel__description">
-                Click a button above to switch between Main Editor and Formatted Pages — huge update: you can edit it from the formatted pages bit while this left panel stays visible and the tools on the right scroll.
+                Toggle between the drafting canvas and formatted pages whenever you need a different view.
               </p>
             </div>
             <div class="writing-panel__controls">
@@ -212,13 +212,11 @@
             <div class="status-bar">
               <div class="status-left">
                 <span class="status-tip-label">Flow tip</span>
-                <p class="status-tip">
-                  Press <kbd>Tab</kbd> to align dialogue instantly or use the snippet keys to insert elements.
-                </p>
+                <p class="status-tip">Use snippet buttons or <kbd>Tab</kbd> to line up dialogue without leaving the keyboard.</p>
               </div>
               <div class="status-right">
-                <span class="hint-chip">⌘ + S exports a Fountain copy</span>
-                <span class="hint-chip">Use Outline to jump between beats</span>
+                <span class="hint-chip">⌘ + S saves a Fountain copy</span>
+                <span class="hint-chip">Outline helps you jump between scenes</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- refresh the header with a calmer intro, concise highlight pills, and updated helper copy
- soften the color palette, background canvas, and component surfaces for a cleaner writing space
- polish toolbar, editor, hint, and stats styling for both light and dark themes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d37721e16c832b801aa7b4f5efcaa6