### PR TITLE
Add story direction AI toolbox

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -885,6 +885,46 @@ kbd {
   gap: 1.25rem;
 }
 
+.ai-card__intro {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-soft);
+  line-height: 1.5;
+}
+
+.ai-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ai-card__actions button {
+  flex-shrink: 0;
+}
+
+.ai-card__status {
+  font-size: 0.85rem;
+  color: var(--text-soft);
+}
+
+.ai-card__output {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--panel-border);
+  background: var(--panel);
+  padding: 1rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--text);
+  white-space: pre-wrap;
+}
+
+.ai-card__output.is-error {
+  border-color: var(--danger-soft);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
 .side-rail .panel {
   background: var(--panel-solid);
 }

--- a/index.html
+++ b/index.html
@@ -242,6 +242,23 @@
               </div>
             </section>
 
+            <section class="panel side-card ai-card" aria-label="AI toolbox">
+              <div class="panel-section">
+                <div class="panel-section-heading">
+                  <h3>AI Toolbox</h3>
+                  <span class="panel-hint">Ask for a next beat when you feel stuck.</span>
+                </div>
+                <p class="ai-card__intro">
+                  Story Direction looks at your draft and quick beats to suggest what could happen next.
+                </p>
+                <div class="ai-card__actions">
+                  <button type="button" class="ghost" id="storyDirectionBtn">Story direction</button>
+                  <span class="ai-card__status" id="storyDirectionStatus" role="status" aria-live="polite"></span>
+                </div>
+                <article class="ai-card__output" id="storyDirectionOutput" hidden aria-live="polite"></article>
+              </div>
+            </section>
+
             <section class="panel side-card insights-card" aria-label="Insights">
               <div class="panel-section">
                 <div class="panel-section-heading">


### PR DESCRIPTION
## Summary
- add an AI Toolbox panel in the side rail focused on Story Direction support
- connect the Story Direction button to the HiStageReasoning endpoint to propose next-scene ideas using the draft and quick beats
- style the toolbox output area and surface loading and error states for the generated guidance

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d4c7e8bf5c832ba215179cb23fd73c