### PR TITLE
Revamp AI toolbox implementation flow

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -960,6 +960,68 @@ kbd {
   flex-shrink: 0;
 }
 
+.ai-card__implement-btn {
+  background: var(--positive-soft);
+  color: var(--positive);
+  font-weight: 600;
+  border-color: transparent;
+}
+
+.ai-card__implement-btn:hover {
+  background: rgba(22, 163, 74, 0.2);
+  color: var(--positive);
+}
+
+[data-theme='dark'] .ai-card__implement-btn {
+  background: rgba(74, 222, 128, 0.28);
+  color: #052e16;
+}
+
+[data-theme='dark'] .ai-card__implement-btn:hover {
+  background: rgba(74, 222, 128, 0.36);
+  color: #052e16;
+}
+
+.ai-card__implementation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--positive);
+  background: rgba(22, 163, 74, 0.08);
+  padding: 0.75rem 0.85rem;
+}
+
+[data-theme='dark'] .ai-card__implementation {
+  background: rgba(74, 222, 128, 0.12);
+  border-color: var(--positive);
+}
+
+.ai-card__implementation-text {
+  margin: 0;
+  white-space: pre-wrap;
+  color: var(--positive);
+}
+
+.ai-card__implementation[data-state='committed'] {
+  border-style: solid;
+  background: var(--panel);
+}
+
+.ai-card__implementation[data-state='committed'] .ai-card__implementation-text {
+  color: var(--text);
+}
+
+.ai-card__implementation-actions {
+  display: inline-flex;
+  gap: 0.45rem;
+}
+
+.ai-card__implementation-actions button {
+  width: 36px;
+  height: 36px;
+}
+
 .ai-card__feedback {
   display: inline-flex;
   gap: 0.35rem;
@@ -993,6 +1055,10 @@ kbd {
 .ai-card__output.is-error {
   border-color: var(--danger-soft);
   background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.ai-card__status.is-error {
   color: var(--danger);
 }
 

--- a/index.html
+++ b/index.html
@@ -261,29 +261,35 @@
                 <article class="ai-card__output" id="storyDirectionOutput" hidden aria-live="polite">
                   <p class="ai-card__idea" id="storyDirectionText"></p>
                   <div class="ai-card__idea-actions" id="storyDirectionActions" hidden>
-                    <button type="button" class="primary" id="storyDirectionImplementBtn">Implement idea</button>
-                    <div class="ai-card__feedback" role="group" aria-label="Rate this idea">
+                    <button type="button" class="ai-card__implement-btn" id="storyDirectionImplementBtn">
+                      Implement idea
+                    </button>
+                    <button type="button" class="ghost" id="storyDirectionRegenerateIdeaBtn">
+                      Regenerate idea
+                    </button>
+                  </div>
+                  <div class="ai-card__implementation" id="storyDirectionImplementation" hidden>
+                    <p class="ai-card__implementation-text" id="storyDirectionImplementationText"></p>
+                    <div class="ai-card__implementation-actions" id="storyDirectionImplementationActions">
                       <button
                         type="button"
                         class="ghost icon"
-                        id="storyDirectionApproveBtn"
-                        data-feedback="approve"
-                        aria-label="Mark idea as helpful"
+                        id="storyDirectionCommitBtn"
+                        aria-label="Add implementation to script"
                       >
                         ✓
                       </button>
                       <button
                         type="button"
                         class="ghost icon"
-                        id="storyDirectionRejectBtn"
-                        data-feedback="reject"
-                        aria-label="Dismiss this idea"
+                        id="storyDirectionDiscardBtn"
+                        aria-label="Discard implementation"
                       >
                         ✕
                       </button>
                     </div>
                   </div>
-                  <p class="ai-card__feedback-status" id="storyDirectionFeedbackStatus" hidden></p>
+                  <p class="ai-card__status" id="storyDirectionImplementStatus" hidden></p>
                 </article>
               </div>
             </section>


### PR DESCRIPTION
## Summary
- add regenerate and implementation controls to the AI Toolbox panel
- style the new AI assistant actions and implementation preview states
- rework the Story Direction logic to fetch implementation text, manage commit/discard actions, and append accepted output to the script

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4ceeb4e54832bb66951e27f3a5c70